### PR TITLE
import optimization (do not create draft if not necessary)

### DIFF
--- a/classes/content/sqlicontentpublisher.php
+++ b/classes/content/sqlicontentpublisher.php
@@ -110,7 +110,8 @@ class SQLIContentPublisher
                 continue;
             }
             
-            if ( is_null( $version ) ) { // Create new $version only if necessary (this is an optimization : $version->removeThis() is very very slow !)
+            if ( is_null( $version ) ) // Create new $version only if necessary (this is an optimization : $version->removeThis() is very very slow !)
+            {
                 $version = $this->createNewVersion( $content );
             }
             


### PR DESCRIPTION
The $version->removeThis() action (that deletes a not modified draft) takes a lot of resources and is very slow to execute, so I've suggested to create a new draft only if there is any change, so there are no draft to delete if there are no changes :-)
