### PR TITLE
Fixed bug in sqliiimporthandler options to handleuris with equal signs

### DIFF
--- a/classes/sourcehandlers/options/sqliimporthandleroptions.php
+++ b/classes/sourcehandlers/options/sqliimporthandleroptions.php
@@ -63,7 +63,7 @@ class SQLIImportHandlerOptions extends SQLIImportOptions
         foreach( $aOptionsLines as $optionLine )
         {
             $optionLine = trim( $optionLine );
-            list( $optionName, $optionValue ) = explode( '=', $optionLine );
+            list( $optionName, $optionValue ) = explode( '=', $optionLine, 2 );
             $aOptions[$optionName] = $optionValue;
         }
         


### PR DESCRIPTION
We use option values with equal signs. But they were not supported by the option handler.
