### PR TITLE
Implemented: Support for static cache delay to cronjob feature

### DIFF
--- a/classes/sqliimportutils.php
+++ b/classes/sqliimportutils.php
@@ -269,6 +269,7 @@ class SQLIImportUtils
             }
             unset( $aObjectsToClear );
             eZContentObject::clearCache();
+            eZStaticCache::executeActions();
         }
         while( $i < $count );
         


### PR DESCRIPTION
Hello,

First, Thank you for such a wonderful extension as sqliimport. We love working with your extension!
# The problem

We recently implemented static cache support for a site and found that content imported with sqliimport did not get static cache created when clearing the view cache via the 'sqliimport_cleanup' cronjob.

After some research we found that static cache was not being created because we use the staticcache.ini:[CacheSettings] CronjobCacheClear=enabled setting AND because when 'sqliimport_cleanup' cronjob runs to clear the view cache it did not include support for actually storing the requests for static cache updates in the ezpending_actions table because it lacks a call to 'eZStaticCache::executeActions()' function which does this work.
# The solution

The solution to the above problem was to add a line of code used by the 'sqliimport_cleanup' cronjob part to call 'eZStaticCache::executeActions()' function which stores delayed requests to update static cache. Without this change the requests to delay static cache updates are never stored and thus never able to performed. For us this was a big negative feature creating a gaping hole in our otherwise perfect static cache setup.
# Closing

Please review this pull request. 

This change makes it possible for us to continue to sqliimport extension and CronjobCacheClear=enabled setting and we would really appreciate it if we did not have to maintain a patch to this extension in a fork.

Please let us know what you think.

Thank you for your continued support!

Cheers,
Brookins Consulting
