### PR TITLE
SQLIContentField never returns identifier

### DIFF
--- a/classes/content/sqlicontentfield.php
+++ b/classes/content/sqlicontentfield.php
@@ -110,6 +110,7 @@ class SQLIContentField
                 break;
             case 'identifier':
                 $ret = $this->identifier;
+                break;
             default:
                 if ( $this->attribute->hasAttribute( $name ) )
                     $ret = $this->attribute->attribute( $name );


### PR DESCRIPTION
Due to a missing `break`, `SQLIContentField` would never return an identifier, when requested, but always the `name` attribute, or an exception.

Cheers
:octocat: Jérôme