### PR TITLE
Avoid output to STDERR

### DIFF
--- a/classes/sqliimportfactory.php
+++ b/classes/sqliimportfactory.php
@@ -241,7 +241,7 @@ final class SQLIImportFactory
                 );
                 $progressBar = new ezcConsoleProgressbar( $this->output, $processLength, $progressBarOptions );
                 $progressBar->start();
-                $this->cli->warning( 'Now processing "'.$handlerName.'" handler.' );
+                $this->cli->output( $this->cli->stylize( 'warning', 'Now processing "'.$handlerName.'" handler.' ) );
                 
                 $isInterrupted = false;
                 while( $row = $importHandler->getNextRow() )
@@ -269,7 +269,7 @@ final class SQLIImportFactory
                     // Interruption handling
                     if( $aImportItems[$i]->isInterrupted() )
                     {
-                        $this->cli->notice();
+                        $this->cli->output();
                         SQLIImportLogger::logNotice( 'Interruption has been requested for current import ! Cleaning and aborting process...' );
                         $isInterrupted = true;
                         break;
@@ -278,7 +278,7 @@ final class SQLIImportFactory
                 
                 $importHandler->cleanup();
                 $progressBar->finish();
-                $this->cli->notice();
+                $this->cli->output();
                 unset( $importHandler );
                 
                 

--- a/classes/sqliimportlogger.php
+++ b/classes/sqliimportlogger.php
@@ -107,14 +107,14 @@ class SQLIImportLogger
         {
             case self::ERRORLOG:
                 if( !$isWebOutput )
-                    self::$cli->error( $msg );
+                    self::$cli->output( self::$cli->stylize( 'error', $msg ) );
                 else
                     eZDebug::writeError( $msg, 'SQLIImport' );
             break;
             
             case self::WARNINGLOG:
                 if( !$isWebOutput )
-                    self::$cli->warning( $msg );
+                    self::$cli->output( self::$cli->stylize( 'warning', $msg ) );
                 else
                     eZDebug::writeWarning( $msg, 'SQLIImport' );
             break;
@@ -122,7 +122,7 @@ class SQLIImportLogger
             case self::NOTICELOG:
             default:
                 if( !$isWebOutput )
-                    self::$cli->notice( $msg );
+                    self::$cli->output( self::$cli->stylize( 'notice', $msg ) );
                 else
                     eZDebug::writeNotice( $msg, 'SQLIImport' );
             break;


### PR DESCRIPTION
eZCLI writes notices, warnings and errors to STDERR, which should not be wanted here.

This behavior was discovered by @meckhardt, so props to him :)

:octocat: 
